### PR TITLE
Added storage feature, connected drives and free space

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Supported services:
   - mark phone call as read
   - reboot the Freebox Server
   - display the system information
+  - get storage status
 
 
 #### Dependancies:
@@ -60,7 +61,7 @@ JSON format:
 
 ```bash
 usage: fbxosctrl.py [-h] [--version] [-v] [-j]
-                    (--regapp | --wrstatus | --wron | --wroff | --wpstatus | --wpon | --wpoff | --dhcpleases | --clist | --cnew | --cread | --reboot | --sinfo)
+                    (--regapp | --wrstatus | --wron | --wroff | --wpstatus | --wpon | --wpoff | --dhcpleases | --clist | --cnew | --cread | --reboot | --sinfo | --dlist | --dspace)
 
 Command line utility to control some FreeboxOS services.
 
@@ -83,4 +84,6 @@ optional arguments:
   --cread       set read status for all received calls
   --reboot      reboot the Freebox Server now!
   --sinfo       display the system information
+  --dlist       display connected drives
+  --dspace      display free space on connected drives
 ```


### PR DESCRIPTION
Here is a new feature I added for my personnal usage.
I'm not sure it's very useful for others but I'll let you judge if it worth merging into your repo.

it generate such outputs : 

```
nico@rpi-stable:/usr/local/src/fbxosctrl (master) $ fbxosctrl.py --dlist
Freebox Server is accessible via: https://......:8476
Drives connected :
 - HGST HCC545025A7E380 (3F113P5E) - Spinning
 - SAMSUNG HD204UI (S2H7J9GB908161) - Spinning
 - _no_brand_ (_no_serial_)

```

```
nico@rpi-stable:/usr/local/src/fbxosctrl (master) $ fbxosctrl.py --dspace
Freebox Server is accessible via: https://......:8476
Storage info:
 - HGST HCC545025A7E380
     #Disque dur      :  147Go / 228Go
 - SAMSUNG HD204UI
     #Volume 1996Go   :  144Go /1825Go
 - _no_brand_
     #NO NAME         :  115Mo / 120Mo
     #Volume 42Go     :   28Go /  39Go
     #                :    0Mo /   0Mo
     #ORICO           :   36Go / 422Go
```
